### PR TITLE
v0.0.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ jobs:
   pypi-publish:
     name: PyPI Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -3,8 +3,8 @@
 Release Notes
 -------------
 
-Future Release
-==============
+v0.0.3 Mar 29, 2024
+===================
     * Remove pandas version upper bound restriction and add Python 3.11 tests (:pr:`16`)
     * Remove support for Python 3.8 (:pr:`22`)
 

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
 
 .. Thanks to the following people for contributing to this release:
 
-v0.0.3 Mar 29, 2024
+v0.0.3 Mar 19, 2024
 ===================
     * Remove pandas version upper bound restriction and add Python 3.11 tests (:pr:`16`)
     * Remove support for Python 3.8 (:pr:`22`)

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -3,6 +3,16 @@
 Release Notes
 -------------
 
+.. Future Release
+  ==============
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
 v0.0.3 Mar 29, 2024
 ===================
     * Remove pandas version upper bound restriction and add Python 3.11 tests (:pr:`16`)


### PR DESCRIPTION
**v0.0.3 Mar 19, 2024**
    * Remove pandas version upper bound restriction and add Python 3.11 tests (#16)
    * Remove support for Python 3.8 (#22)